### PR TITLE
Dedup fields - Improve Coverage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,24 @@
+## 0.0.3 (unreleased)
+
+### Added
+
+### Changed
+
+- Remove fields from `sexps_rewriters` that are duplicated from `t.file_rewriter` (refactor).
+
+### Deprecated
+
+### Fixed
+
+- Improve test coverage.
+
+### Removed
+
 ## 0.0.2 (2024-09-04)
 
 ### Added
 
-- Add new tests and increase code coverage
+- Add new tests and increase code coverage.
 
 ### Changed
 

--- a/lib/file_rewriter/src/file_rewriter.ml
+++ b/lib/file_rewriter/src/file_rewriter.ml
@@ -48,6 +48,8 @@ type t =
   ; mutable rewrites : Rewrite.t list (* New elements added to the front. *)
   }
 
+let path t = t.path
+let original_contents t = t.original_contents
 let create ~path ~original_contents = { path; original_contents; rewrites = [] }
 let reset ({ path = _; original_contents = _; rewrites = _ } as t) = t.rewrites <- []
 

--- a/lib/file_rewriter/src/file_rewriter.mli
+++ b/lib/file_rewriter/src/file_rewriter.mli
@@ -92,3 +92,11 @@ val contents : t -> string
 (** Same as {!val:contents} but wraps the output into a result type rather than
     raising an exception. *)
 val contents_result : t -> (string, Invalid_rewrites.t) Result.t
+
+(** {1 Getters} *)
+
+(** Returns the path that was supplied to [create]. *)
+val path : t -> Fpath.t
+
+(** Returns the original contents that was supplied to [create]. *)
+val original_contents : t -> string

--- a/lib/file_rewriter/test/test__file_rewriter.ml
+++ b/lib/file_rewriter/test/test__file_rewriter.ml
@@ -23,8 +23,16 @@ Hello Newline
 
 let%expect_test "insert" =
   let file_rewriter = File_rewriter.create ~path:(Fpath.v "foo.txt") ~original_contents in
+  print_endline (File_rewriter.path file_rewriter |> Fpath.to_string);
+  [%expect {| foo.txt |}];
   let reset () = File_rewriter.reset file_rewriter in
   let test () = print_endline (File_rewriter.contents file_rewriter) in
+  (* The original contents may be accessed. *)
+  require_equal
+    [%here]
+    (module String)
+    original_contents
+    (File_rewriter.original_contents file_rewriter);
   (* Applying no substitution shall return the original contents. *)
   require_equal
     [%here]

--- a/lib/sexps_rewriter/src/sexps_rewriter.ml
+++ b/lib/sexps_rewriter/src/sexps_rewriter.ml
@@ -15,27 +15,17 @@
 (******************************************************************************)
 
 type t =
-  { path : Fpath.t
-  ; original_contents : string
-  ; original_sexps : Sexp.t list
+  { original_sexps : Sexp.t list
   ; positions : Parsexp.Positions.t
   ; file_rewriter : File_rewriter.t
   ; parser_result : Parsexp.Many_and_positions.parsed_value
   }
 
-let reset
-  { path = _
-  ; original_contents = _
-  ; original_sexps = _
-  ; positions = _
-  ; file_rewriter
-  ; parser_result = _
-  }
-  =
+let reset { original_sexps = _; positions = _; file_rewriter; parser_result = _ } =
   File_rewriter.reset file_rewriter
 ;;
 
-let path t = t.path
+let path t = File_rewriter.path t.file_rewriter
 let contents t = File_rewriter.contents t.file_rewriter
 let contents_result t = File_rewriter.contents_result t.file_rewriter
 let file_rewriter t = t.file_rewriter
@@ -53,7 +43,7 @@ module Position = struct
     Loc.create (source_code_position range.start_pos, source_code_position range.end_pos)
   ;;
 
-  let loc t range = loc_of_parsexp_range ~path:t.path range
+  let loc t range = loc_of_parsexp_range ~path:(File_rewriter.path t.file_rewriter) range
 
   let range (range : Parsexp.Positions.range) =
     { Loc.Range.start = range.start_pos.offset; stop = range.end_pos.offset }
@@ -128,9 +118,7 @@ let create ~path ~original_contents =
   match Parsexp.Many_and_positions.parse_string original_contents with
   | Ok ((original_sexps, positions) as parser_result) ->
     Ok
-      { path
-      ; original_contents
-      ; original_sexps
+      { original_sexps
       ; positions
       ; file_rewriter = File_rewriter.create ~path ~original_contents
       ; parser_result


### PR DESCRIPTION
### Changed

- Remove fields from `sexps_rewriters` that are duplicated from `t.file_rewriter` (refactor).

### Fixed

- Improve test coverage.