### PR TITLE
Upgrade to and require pplumbing 0.0.17 in tests

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -70,7 +70,7 @@
   (pp
    (>= 2.0.0))
   (pplumbing-err
-   (>= 0.0.16))
+   (>= 0.0.17))
   (ppx_expect
    (>= v0.17))
   (ppxlib

--- a/file-rewriter-tests.opam
+++ b/file-rewriter-tests.opam
@@ -17,7 +17,7 @@ depends: [
   "ordering" {>= "3.17"}
   "parsexp" {>= "v0.17"}
   "pp" {>= "2.0.0"}
-  "pplumbing-err" {>= "0.0.16"}
+  "pplumbing-err" {>= "0.0.17"}
   "ppx_expect" {>= "v0.17"}
   "ppxlib" {>= "0.33"}
   "sexplib0" {>= "v0.17"}

--- a/src/stdlib/code_error0.ml
+++ b/src/stdlib/code_error0.ml
@@ -4,18 +4,4 @@
 (*  SPDX-License-Identifier: Apache-2.0                                          *)
 (*********************************************************************************)
 
-type t =
-  { message : string
-  ; data : (string * Dyn.t) list
-  }
-
-exception E of t
-
-let raise message data = raise (E { message; data })
-let to_dyn { message; data } = Dyn.Tuple [ Dyn.String message; Record data ]
-
-let () =
-  Printexc.register_printer (function
-    | E t -> Some (Dyn.to_string (to_dyn t))
-    | _ -> None [@coverage off])
-;;
+include Pplumbing_err.Code_error

--- a/src/stdlib/code_error0.mli
+++ b/src/stdlib/code_error0.mli
@@ -4,15 +4,6 @@
 (*_  SPDX-License-Identifier: Apache-2.0                                          *)
 (*_********************************************************************************)
 
-(*_ Inspired by a similar module in stdune. *)
-
-(** A programming error that should be reported upstream *)
-
-type t =
-  { message : string
-  ; data : (string * Dyn.t) list
-  }
-
-exception E of t
-
-val raise : string -> (string * Dyn.t) list -> _
+include module type of struct
+  include Pplumbing_err.Code_error
+end

--- a/src/stdlib/dune
+++ b/src/stdlib/dune
@@ -2,7 +2,7 @@
  (name stdlib_for_test)
  (package file-rewriter-tests)
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a)
- (libraries dyn file_rewriter_myers ordering pp)
+ (libraries dyn file_rewriter_myers ordering pp pplumbing-err)
  (instrumentation
   (backend bisect_ppx))
  (lint

--- a/src/stdlib/err0.ml
+++ b/src/stdlib/err0.ml
@@ -1,0 +1,7 @@
+(*********************************************************************************)
+(*  file-rewriter: Apply small rewrites to tweak or refactor your files          *)
+(*  SPDX-FileCopyrightText: 2024-2026 Mathieu Barbin <mathieu.barbin@gmail.com>  *)
+(*  SPDX-License-Identifier: Apache-2.0                                          *)
+(*********************************************************************************)
+
+include Pplumbing_err.Err

--- a/src/stdlib/err0.mli
+++ b/src/stdlib/err0.mli
@@ -1,0 +1,9 @@
+(*_********************************************************************************)
+(*_  file-rewriter: Apply small rewrites to tweak or refactor your files          *)
+(*_  SPDX-FileCopyrightText: 2024-2026 Mathieu Barbin <mathieu.barbin@gmail.com>  *)
+(*_  SPDX-License-Identifier: Apache-2.0                                          *)
+(*_********************************************************************************)
+
+include module type of struct
+  include Pplumbing_err.Err
+end

--- a/src/stdlib/pp0.ml
+++ b/src/stdlib/pp0.ml
@@ -1,0 +1,7 @@
+(*********************************************************************************)
+(*  file-rewriter: Apply small rewrites to tweak or refactor your files          *)
+(*  SPDX-FileCopyrightText: 2024-2026 Mathieu Barbin <mathieu.barbin@gmail.com>  *)
+(*  SPDX-License-Identifier: Apache-2.0                                          *)
+(*********************************************************************************)
+
+include Pp

--- a/src/stdlib/pp0.mli
+++ b/src/stdlib/pp0.mli
@@ -1,0 +1,9 @@
+(*_********************************************************************************)
+(*_  file-rewriter: Apply small rewrites to tweak or refactor your files          *)
+(*_  SPDX-FileCopyrightText: 2024-2026 Mathieu Barbin <mathieu.barbin@gmail.com>  *)
+(*_  SPDX-License-Identifier: Apache-2.0                                          *)
+(*_********************************************************************************)
+
+include module type of struct
+  include Pp
+end

--- a/src/stdlib/stdlib0.ml
+++ b/src/stdlib/stdlib0.ml
@@ -6,9 +6,11 @@
 
 module Code_error = Code_error0
 module Dyn = Dyn0
+module Err = Err0
 module List = List0
 module Myers = Myers0
 module Ordering = Ordering0
+module Pp = Pp0
 module String = String0
 module With_equal_and_dyn = With_equal_and_dyn0
 

--- a/src/stdlib/stdlib0.mli
+++ b/src/stdlib/stdlib0.mli
@@ -6,9 +6,11 @@
 
 module Code_error = Code_error0
 module Dyn = Dyn0
+module Err = Err0
 module List = List0
 module Myers = Myers0
 module Ordering = Ordering0
+module Pp = Pp0
 module String = String0
 module With_equal_and_dyn = With_equal_and_dyn0
 

--- a/test/sexps-rewriter/dune
+++ b/test/sexps-rewriter/dune
@@ -8,18 +8,8 @@
   -warn-error
   +a
   -open
-  Pplumbing_err
-  -open
   Stdlib_for_test)
- (libraries
-  file-rewriter
-  fpath
-  parsexp
-  pp
-  pplumbing-err
-  sexps_rewriter
-  stdlib_for_test
-  unix)
+ (libraries file-rewriter fpath parsexp sexps_rewriter stdlib_for_test unix)
  (inline_tests)
  (instrumentation
   (backend bisect_ppx))

--- a/test/sexps-rewriter/test__sexps_rewriter.ml
+++ b/test/sexps-rewriter/test__sexps_rewriter.ml
@@ -307,9 +307,9 @@ let%expect_test "atom" =
   print_endline (Sexps_rewriter.contents sexps_rewriter);
   [%expect
     {|
-    Hello
     File "path/lib/atom", line 1, characters 0-5:
     Warning: This is an atom.
+    Hello
     |}];
   ()
 ;;


### PR DESCRIPTION
The behavior change in the test comes from an upstream fix in the handling of messages flushing (here a warning is produced before the end of the execution).